### PR TITLE
types: declare default export in src/check-answer.d.ts to match README

### DIFF
--- a/src/check-answer.d.ts
+++ b/src/check-answer.d.ts
@@ -1,9 +1,16 @@
-export function checkAnswer(
-    answerline: string,
-    givenAnswer: string,
-    strictness?: number,
-    verbose?: boolean
-): {
-    directive: "accept" | "prompt" | "reject";
-    directedPrompt?: string;
-};
+export type CheckDirective = 'accept' | 'prompt' | 'reject';
+
+export interface CheckResult {
+  directive: CheckDirective;
+  directedPrompt?: string;
+}
+
+declare function checkAnswer(
+  answerline: string,
+  givenAnswer: string,
+  strictness?: number,
+  verbose?: boolean
+): CheckResult;
+
+export default checkAnswer;
+export { checkAnswer };


### PR DESCRIPTION
Update `src/check-answer.d.ts` to declare a **default export** for `checkAnswer` so TypeScript stops yelling when using

```ts
import checkAnswer from 'qb-answer-checker'